### PR TITLE
Add ttyd web terminal service module

### DIFF
--- a/hosts/mara.nix
+++ b/hosts/mara.nix
@@ -85,7 +85,6 @@
         schedule = "0 1 * * *";
       };
       stirlingPdf.enable = true;
-      ttyd.enable = true;
       streaming.jellyfin.enable = true;
       syncthing.enable = true;
       tailscale = {

--- a/hosts/mara.nix
+++ b/hosts/mara.nix
@@ -85,6 +85,7 @@
         schedule = "0 1 * * *";
       };
       stirlingPdf.enable = true;
+      ttyd.enable = true;
       streaming.jellyfin.enable = true;
       syncthing.enable = true;
       tailscale = {

--- a/modules/services/ttyd.linux.nix
+++ b/modules/services/ttyd.linux.nix
@@ -1,0 +1,42 @@
+{ pkgs, lib, config, env, ... }:
+let
+  cfg = config.my.services.ttyd;
+  inherit (cfg) port;
+  portStr = toString port;
+in
+{
+  options.my.services.ttyd = {
+    enable = lib.mkEnableOption "ttyd web terminal";
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 7681;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.ttyd = {
+      enable = true;
+      inherit port;
+      interface = "127.0.0.1";
+      user = env.user;
+      writeable = true;
+      entrypoint = [ (lib.getExe pkgs.zsh) ];
+    };
+
+    systemd.services.ttyd.path = [ pkgs.zsh ];
+
+    environment.systemPackages = with pkgs; [
+      (writeShellScriptBin "tailscale-svc-ttyd-up" ''
+        tailscale serve --service=svc:ttyd --https=443 http://127.0.0.1:${portStr}
+      '')
+      (writeShellScriptBin "tailscale-svc-ttyd-down" ''
+        tailscale serve clear svc:ttyd
+      '')
+    ];
+
+    my.services.homepage.services."ttyd" = {
+      description = "Web terminal";
+      href = "https://ttyd.dinosaur-crocodile.ts.net";
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Add `my.services.ttyd` wrapping NixOS ttyd (writable zsh, loopback bind, Tailscale helpers, homepage entry)
- Module kept available; not enabled on mara

## Test plan
- [x] `just check` passes
- [ ] Enable on a host and run `tailscale-svc-ttyd-up` when ready to use