### PR TITLE
Extract shared host enables into a dev-workstation profile

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -277,13 +277,14 @@
             bunScriptsPackage = bun-scripts.packages.${linuxSystem}.default;
             stirlingPdfPackage = stirling-pdf.packages.${linuxSystem}.stirling-pdf;
           };
+          # Hosts after shared modules so plain host assignments override profile enables.
           modules = [
             inputs.home-manager.nixosModules.home-manager
             createNixCache
             { }
-            ./hosts/akatosh.nix
             importLinuxModules
             { }
+            ./hosts/akatosh.nix
           ];
         };
 
@@ -314,9 +315,9 @@
             inputs.home-manager.nixosModules.home-manager
             createNixCache
             { }
-            ./hosts/azura.nix
             importLinuxModules
             { }
+            ./hosts/azura.nix
           ];
         };
 
@@ -347,9 +348,9 @@
             home-manager.nixosModules.home-manager
             createNixCache
             { }
-            ./hosts/mara.nix
             importLinuxModules
             { }
+            ./hosts/mara.nix
           ];
         };
       };
@@ -372,9 +373,9 @@
             };
             modules = [
               home-manager.darwinModules.home-manager
-              ./hosts/boethiah.nix
               importDarwinModules
               { }
+              ./hosts/boethiah.nix
             ];
           };
         in

--- a/hosts/akatosh.nix
+++ b/hosts/akatosh.nix
@@ -10,6 +10,7 @@ let
 in
 {
   my = {
+    profiles.devWorkstation.enable = true;
     desktop = {
       hyprland = {
         enable = true;
@@ -49,17 +50,6 @@ in
       # gnome.enable = true;
     };
     programs = {
-      agents = {
-        enable = true;
-        sandbox.enable = true;
-      };
-      devPkgs.enable = true;
-      jsPackageSecurity.enable = true;
-      claude-code.enable = true;
-      rtk.enable = true;
-      herdr.enable = true;
-      hunk.enable = true;
-      cursor.enable = true;
       opencode = {
         enable = true;
         providers = {
@@ -69,20 +59,10 @@ in
         };
       };
       games.enable = true;
-      gws.enable = true;
-      localsend.enable = true;
-      obsidian.enable = true;
       desktopPkgs.enable = true;
-      kitty.enable = true;
-      rofi.enable = true;
-      ydotool.enable = true;
-      micro = {
-        isDefaultEditor = true;
-      };
       comma.enable = true;
       ms-apps.enable = true;
     };
-    scripts.bun.enable = true;
     services = {
       stylix = {
         enable = true;

--- a/hosts/azura.nix
+++ b/hosts/azura.nix
@@ -44,6 +44,7 @@ in
   ];
 
   my = {
+    profiles.devWorkstation.enable = true;
     desktop = {
       hyprland = {
         enable = true;
@@ -55,30 +56,9 @@ in
       uiShell = "ags";
     };
     programs = {
-      agents = {
-        enable = true;
-        sandbox.enable = true;
-      };
-      devPkgs.enable = true;
-      micro = {
-        isDefaultEditor = true;
-      };
-      jsPackageSecurity.enable = true;
-      claude-code.enable = true;
-      rtk.enable = true;
-      herdr.enable = true;
-      hunk.enable = true;
-      cursor.enable = true;
       onscreenKeyboard.enable = true;
-      gws.enable = true;
-      localsend.enable = true;
-      obsidian.enable = true;
       desktopPkgs.enable = true;
-      kitty.enable = true;
-      rofi.enable = true;
-      ydotool.enable = true;
     };
-    scripts.bun.enable = true;
     services = {
       syncthing.enable = true;
       stylix = {

--- a/hosts/boethiah.nix
+++ b/hosts/boethiah.nix
@@ -5,6 +5,7 @@
 }:
 {
   my = {
+    profiles.devWorkstation.enable = true;
     services = {
       # docker.enable = true;
       podman = {
@@ -13,23 +14,8 @@
       };
     };
     programs = {
-      agents = {
-        enable = true;
-        sandbox.enable = true;
-      };
-      devPkgs.enable = true;
-      micro = {
-        isDefaultEditor = true;
-      };
-      jsPackageSecurity.enable = true;
-      claude-code.enable = true;
-      localsend.enable = true;
-      obsidian.enable = true;
-      cursor.enable = true;
       desktopPkgs.enable = true;
       warp.enable = true;
-      gws.enable = true;
-      herdr.enable = true;
       # Disabled: hunk's bun2nix build fetches npm packages at build time,
       # and IT blocks the npm registry on this machine.
       hunk.enable = false;

--- a/hosts/mara.nix
+++ b/hosts/mara.nix
@@ -10,18 +10,8 @@
   ];
 
   my = {
+    profiles.devWorkstation.enable = true;
     programs = {
-      agents = {
-        enable = true;
-        sandbox.enable = true;
-      };
-      devPkgs.enable = true;
-      jsPackageSecurity.enable = true;
-      claude-code.enable = true;
-      rtk.enable = true;
-      herdr.enable = true;
-      hunk.enable = true;
-      cursor.enable = true;
       opencode = {
         enable = true;
         web.enable = true;
@@ -31,20 +21,12 @@
         };
       };
       # mobile-dev.enable = false;
-      gws.enable = true;
-      obsidian.enable = true;
       # tmux.enable = true;
       # zellij = {
       #   enable = true;
       #   autoStart.enable = true;
       # };
-      kitty.enable = true; # Needed for when we ssh into this host
-      micro = {
-        isDefaultEditor = true;
-      };
-      localsend.enable = true;
     };
-    scripts.bun.enable = true;
     services = {
       dnsAdBlock.enable = true;
       cockpit = let port = 19090; in {

--- a/modules/profiles/dev-workstation.nix
+++ b/modules/profiles/dev-workstation.nix
@@ -9,24 +9,32 @@ in
   config = lib.mkIf cfg.enable (
     lib.mkMerge [
       {
-        my.programs.agents.enable = lib.mkDefault true;
-        my.programs.devPkgs.enable = lib.mkDefault true;
-        my.programs.jsPackageSecurity.enable = lib.mkDefault true;
-        my.programs.claude-code.enable = lib.mkDefault true;
-        my.programs.cursor.enable = lib.mkDefault true;
-        my.programs.gws.enable = lib.mkDefault true;
-        my.programs.localsend.enable = lib.mkDefault true;
-        my.programs.obsidian.enable = lib.mkDefault true;
-        my.programs.herdr.enable = lib.mkDefault true;
-        my.programs.micro.enable = lib.mkDefault true;
-        my.programs.micro.isDefaultEditor = lib.mkDefault true;
+        my.programs = {
+          agents.enable = true;
+          devPkgs.enable = true;
+          jsPackageSecurity.enable = true;
+          claude-code.enable = true;
+          cursor.enable = true;
+          gws.enable = true;
+          localsend.enable = true;
+          obsidian.enable = true;
+          herdr.enable = true;
+          micro = {
+            enable = true;
+            isDefaultEditor = true;
+          };
+        };
       }
       (env.selectPlatform {
         linux = {
-          my.programs.rtk.enable = lib.mkDefault true;
-          my.programs.hunk.enable = lib.mkDefault true;
-          my.scripts.bun.enable = lib.mkDefault true;
-          my.programs.kitty.enable = lib.mkDefault true;
+          my = {
+            programs = {
+              rtk.enable = true;
+              hunk.enable = true;
+              kitty.enable = true;
+            };
+            scripts.bun.enable = true;
+          };
         };
       })
     ]

--- a/modules/profiles/dev-workstation.nix
+++ b/modules/profiles/dev-workstation.nix
@@ -1,0 +1,34 @@
+# Shared dev-workstation program enables for personal machines.
+{ config, lib, env, ... }:
+let
+  cfg = config.my.profiles.devWorkstation;
+in
+{
+  options.my.profiles.devWorkstation.enable = lib.mkEnableOption "Enable the dev workstation program profile.";
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        my.programs.agents.enable = lib.mkDefault true;
+        my.programs.devPkgs.enable = lib.mkDefault true;
+        my.programs.jsPackageSecurity.enable = lib.mkDefault true;
+        my.programs.claude-code.enable = lib.mkDefault true;
+        my.programs.cursor.enable = lib.mkDefault true;
+        my.programs.gws.enable = lib.mkDefault true;
+        my.programs.localsend.enable = lib.mkDefault true;
+        my.programs.obsidian.enable = lib.mkDefault true;
+        my.programs.herdr.enable = lib.mkDefault true;
+        my.programs.micro.enable = lib.mkDefault true;
+        my.programs.micro.isDefaultEditor = lib.mkDefault true;
+      }
+      (env.selectPlatform {
+        linux = {
+          my.programs.rtk.enable = lib.mkDefault true;
+          my.programs.hunk.enable = lib.mkDefault true;
+          my.scripts.bun.enable = lib.mkDefault true;
+          my.programs.kitty.enable = lib.mkDefault true;
+        };
+      })
+    ]
+  );
+}

--- a/modules/programs/agents/default.nix
+++ b/modules/programs/agents/default.nix
@@ -95,20 +95,22 @@ in
 
   config = lib.mkIf cfg.enable {
     assertions = lib.concatLists (
-      lib.mapAttrsToList (name: server: [
-        {
-          assertion = (server.command != null) != (server.url != null);
-          message = "my.programs.agents.mcp.${name}: exactly one of `command` or `url` must be set.";
-        }
-        {
-          assertion = server.url == null || (server.args == [ ] && server.env == { });
-          message = "my.programs.agents.mcp.${name}: `args` and `env` are only valid for stdio servers (`command`).";
-        }
-        {
-          assertion = server.headers == { } || server.url != null;
-          message = "my.programs.agents.mcp.${name}: `headers` is only valid for remote servers (`url`).";
-        }
-      ]) cfg.mcp
+      lib.mapAttrsToList
+        (name: server: [
+          {
+            assertion = (server.command != null) != (server.url != null);
+            message = "my.programs.agents.mcp.${name}: exactly one of `command` or `url` must be set.";
+          }
+          {
+            assertion = server.url == null || (server.args == [ ] && server.env == { });
+            message = "my.programs.agents.mcp.${name}: `args` and `env` are only valid for stdio servers (`command`).";
+          }
+          {
+            assertion = server.headers == { } || server.url != null;
+            message = "my.programs.agents.mcp.${name}: `headers` is only valid for remote servers (`url`).";
+          }
+        ])
+        cfg.mcp
     );
 
     home-manager.users.${env.user} =
@@ -130,39 +132,43 @@ in
         }
         # Per-file symlinks (not a whole-dir symlink) so tool-specific rules can
         # sit in ~/.cursor/rules/ alongside the shared Claude rules.
-        // lib.mapAttrs' (name: _: {
-          name = ".cursor/rules/${name}.md";
-          value = {
-            source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.claude/rules/${name}.md";
-            force = true;
-          };
-        }) config.programs.claude-code.rules
+        // lib.mapAttrs'
+          (name: _: {
+            name = ".cursor/rules/${name}.md";
+            value = {
+              source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.claude/rules/${name}.md";
+              force = true;
+            };
+          })
+          config.programs.claude-code.rules
         // lib.concatMapAttrs
           # If the dir is a single skill (has SKILL.md), symlink it directly; otherwise
           # treat it as a collection and symlink each subdirectory individually.
           (
             name: dir:
-            if builtins.pathExists "${dir}/SKILL.md" then
-              {
-                ".claude/skills/${name}" = {
-                  source = dir;
-                  recursive = true;
-                };
-              }
-            else
-              lib.mapAttrs' (skillName: _: {
-                name = ".claude/skills/${skillName}";
-                value = {
-                  source = "${dir}/${skillName}";
-                  recursive = true;
-                };
-              }) (lib.filterAttrs (_: type: type == "directory") (builtins.readDir dir))
+              if builtins.pathExists "${dir}/SKILL.md" then
+                {
+                  ".claude/skills/${name}" = {
+                    source = dir;
+                    recursive = true;
+                  };
+                }
+              else
+                lib.mapAttrs'
+                  (skillName: _: {
+                    name = ".claude/skills/${skillName}";
+                    value = {
+                      source = "${dir}/${skillName}";
+                      recursive = true;
+                    };
+                  })
+                  (lib.filterAttrs (_: type: type == "directory") (builtins.readDir dir))
           )
           cfg.skillDirs;
 
         programs = {
           claude-code = {
-            rules = cfg.rules;
+            inherit (cfg) rules;
             # At the moment, cursor supports finding skills in the .claude/skills directory, as do many other agents.
             inherit (cfg) skills;
             # mcpServers requires a non-null package; Darwin uses Homebrew for the binary.

--- a/modules/programs/agents/sandbox.nix
+++ b/modules/programs/agents/sandbox.nix
@@ -79,17 +79,17 @@ let
     ++ lib.optional (cursorApiKeyPath != null) cursorApiKeyPath;
 
   mkAgentSandbox =
-    {
-      pkg,
-      binName,
-      outName,
-      allowedPackages ? [ ],
-      rwDirs ? [ ],
-      rwFiles ? [ ],
-      roDirs ? [ ],
-      roFiles ? [ ],
-      env ? { },
-      allowedDomains ? { },
+    { pkg
+    , binName
+    , outName
+    , allowedPackages ? [ ]
+    , rwDirs ? [ ]
+    , rwFiles ? [ ]
+    , roDirs ? [ ]
+    , roFiles ? [ ]
+    , env ? { }
+    , allowedDomains ? { }
+    ,
     }:
     sbx.mkSandbox {
       inherit

--- a/modules/programs/agents/sandbox.nix
+++ b/modules/programs/agents/sandbox.nix
@@ -190,6 +190,7 @@ in
       ];
     }
     {
+      my.programs.agents.sandbox.enable = lib.mkDefault agentsCfg.enable;
       my.programs.agents.sandbox.agents.claude.enable = lib.mkDefault config.my.programs.claude-code.enable;
       my.programs.agents.sandbox.agents.cursor.enable = lib.mkDefault (
         config.my.programs.opencode.enable or false

--- a/modules/programs/agents/skills.nix
+++ b/modules/programs/agents/skills.nix
@@ -30,7 +30,7 @@ in
             }
           ))
           + ''
-          - When reporting information to me, be extremely concise and sacrifice grammar for sake of concision.
+            - When reporting information to me, be extremely concise and sacrifice grammar for sake of concision.
           '';
         git = ''
           ## Git

--- a/modules/programs/hunk.nix
+++ b/modules/programs/hunk.nix
@@ -37,9 +37,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    my.programs.agents.skillDirs.hunk-review = lib.mkIf (
-      cfg.enableClaudeIntegration && config.my.programs.agents.enable
-    ) "${hunkPackage}/skills/hunk-review";
+    my.programs.agents.skillDirs.hunk-review = lib.mkIf
+      (
+        cfg.enableClaudeIntegration && config.my.programs.agents.enable
+      ) "${hunkPackage}/skills/hunk-review";
 
     home-manager.users.${env.user} = {
       imports = [ inputs.hunk.homeManagerModules.default ];

--- a/modules/programs/localsend.nix
+++ b/modules/programs/localsend.nix
@@ -10,10 +10,10 @@ in
       environment.systemPackages = with pkgs; [
         jocalsend # Rust based TUI for localsend
       ];
-	  programs.localsend = {
-	    enable = true;
-	    openFirewall = true;
-	  };
+      programs.localsend = {
+        enable = true;
+        openFirewall = true;
+      };
     };
     darwin.homebrew.casks = [ "localsend" ];
   });

--- a/modules/scripts/bun/_bun.nix
+++ b/modules/scripts/bun/_bun.nix
@@ -5,12 +5,11 @@
 # Consume this with `fetchBunDeps` (recommended)
 # or `pkgs.callPackage` if you wish to handle
 # it manually.
-{
-  copyPathToStore,
-  fetchFromGitHub,
-  fetchgit,
-  fetchurl,
-  ...
+{ copyPathToStore
+, fetchFromGitHub
+, fetchgit
+, fetchurl
+, ...
 }:
 {
   "@babel/code-frame@7.29.0" = fetchurl {

--- a/modules/services/headroom/_package.nix
+++ b/modules/services/headroom/_package.nix
@@ -1,13 +1,12 @@
 # Headroom CLI via pinned uvx (PyPI). Avoids packaging the full Python/Rust tree
 # in Nix; first run caches the tool under the user's uv cache.
-{
-  lib,
-  writeShellApplication,
-  uv,
-  python313,
-  rtk,
-  stdenv,
-  ...
+{ lib
+, writeShellApplication
+, uv
+, python313
+, rtk
+, stdenv
+, ...
 }:
 let
   # PyPI CLI version; independent of the Docker image tag in headroom.linux.nix.

--- a/modules/services/pia.linux/_profiles.nix
+++ b/modules/services/pia.linux/_profiles.nix
@@ -1,822 +1,822 @@
 {
-        PIA-Albania = {
-          id = "PIA-Albania";
-          uuid = "379fa9ce-746c-4866-9523-41f0e512a3ef";
-          remote = "al.privacy.network 1197 udp";
-        };
-        PIA-Algeria = {
-          id = "PIA-Algeria";
-          uuid = "18bd03e0-8203-4a82-aa97-d63bf436563e";
-          remote = "dz.privacy.network 1197 udp";
-        };
-        PIA-Andorra = {
-          id = "PIA-Andorra";
-          uuid = "9509721c-7411-4161-a1e9-b1c4e0fdc34e";
-          remote = "ad.privacy.network 1197 udp";
-        };
-        PIA-Argentina = {
-          id = "PIA-Argentina";
-          uuid = "f00e17bb-b979-4921-a987-8fbb14a94cc2";
-          remote = "ar.privacy.network 1197 udp";
-        };
-        PIA-Armenia = {
-          id = "PIA-Armenia";
-          uuid = "a8fc3ab5-e60d-42cd-bbb5-e744b54950d4";
-          remote = "yerevan.privacy.network 1197 udp";
-        };
-        PIA-AU_Adelaide = {
-          id = "PIA-AU Adelaide";
-          uuid = "63df32cd-ed45-451b-8b8b-bf65f1ada31e";
-          remote = "au-adelaide-pf.privacy.network 1197 udp";
-        };
-        PIA-AU_Brisbane = {
-          id = "PIA-AU Brisbane";
-          uuid = "7330cff5-7c7c-4ace-993f-e44552e76727";
-          remote = "au-brisbane-pf.privacy.network 1197 udp";
-        };
-        PIA-AU_Melbourne = {
-          id = "PIA-AU Melbourne";
-          uuid = "a69b3e96-43ee-45e5-8b13-a00d27d9dd47";
-          remote = "aus-melbourne.privacy.network 1197 udp";
-        };
-        PIA-AU_Perth = {
-          id = "PIA-AU Perth";
-          uuid = "3819c9e9-00e7-4345-908d-785369ca1a2e";
-          remote = "aus-perth.privacy.network 1197 udp";
-        };
-        PIA-AU_Sydney = {
-          id = "PIA-AU Sydney";
-          uuid = "07cd5a3e-8d88-49d3-9ac7-696f1a955f7e";
-          remote = "au-sydney.privacy.network 1197 udp";
-        };
-        PIA-Australia_Streaming_Optimized = {
-          id = "PIA-Australia Streaming Optimized";
-          uuid = "2a1f6a07-0633-45df-9e9a-fe517895ba00";
-          remote = "au-australia-so.privacy.network 1197 udp";
-        };
-        PIA-Austria = {
-          id = "PIA-Austria";
-          uuid = "38ecd6fa-e7ea-4fb7-8e97-c8fcea7764a8";
-          remote = "austria.privacy.network 1197 udp";
-        };
-        PIA-Bahamas = {
-          id = "PIA-Bahamas";
-          uuid = "36f48c2c-fbcd-4457-974b-3baef64df0aa";
-          remote = "bahamas.privacy.network 1197 udp";
-        };
-        PIA-Bangladesh = {
-          id = "PIA-Bangladesh";
-          uuid = "72e23bb7-6f6d-4eae-a657-b6bd1fc6729a";
-          remote = "bangladesh.privacy.network 1197 udp";
-        };
-        PIA-Belgium = {
-          id = "PIA-Belgium";
-          uuid = "b2739182-2fe7-49f2-a800-c5525b188246";
-          remote = "brussels.privacy.network 1197 udp";
-        };
-        PIA-Bolivia = {
-          id = "PIA-Bolivia";
-          uuid = "994e32dc-74a5-40f1-a0bb-93e736d71e12";
-          remote = "bo-bolivia-pf.privacy.network 1197 udp";
-        };
-        PIA-Bosnia_and_Herzegovina = {
-          id = "PIA-Bosnia and Herzegovina";
-          uuid = "ab894ba3-7cf5-4dbd-9e60-4bd0554205e3";
-          remote = "ba.privacy.network 1197 udp";
-        };
-        PIA-Brazil = {
-          id = "PIA-Brazil";
-          uuid = "75e09ea2-27e1-4215-abf5-c8e363fa0366";
-          remote = "br.privacy.network 1197 udp";
-        };
-        PIA-Bulgaria = {
-          id = "PIA-Bulgaria";
-          uuid = "f97a0639-b3b5-4d39-9635-72c3d23c7989";
-          remote = "sofia.privacy.network 1197 udp";
-        };
-        PIA-CA_Montreal = {
-          id = "PIA-CA Montreal";
-          uuid = "1ede4070-6c77-47f6-8562-6defb7992569";
-          remote = "ca-montreal.privacy.network 1197 udp";
-        };
-        PIA-CA_Ontario = {
-          id = "PIA-CA Ontario";
-          uuid = "fc5adbf7-3ff9-489e-b4be-f52fa9311ae6";
-          remote = "ca-ontario.privacy.network 1197 udp";
-        };
-        PIA-CA_Ontario_Streaming_Optimized = {
-          id = "PIA-CA Ontario Streaming Optimized";
-          uuid = "16a4fd69-8287-400e-bd1c-c3de14315aca";
-          remote = "ca-ontario-so.privacy.network 1197 udp";
-        };
-        PIA-CA_Toronto = {
-          id = "PIA-CA Toronto";
-          uuid = "3349f281-f269-4948-b087-84e38f27ecea";
-          remote = "ca-toronto.privacy.network 1197 udp";
-        };
-        PIA-CA_Vancouver = {
-          id = "PIA-CA Vancouver";
-          uuid = "758754cc-b3c5-4670-a93d-de75389bf3d1";
-          remote = "ca-vancouver.privacy.network 1197 udp";
-        };
-        PIA-Cambodia = {
-          id = "PIA-Cambodia";
-          uuid = "65b71305-93ce-4218-bc9d-285a86e99ab7";
-          remote = "cambodia.privacy.network 1197 udp";
-        };
-        PIA-Chile = {
-          id = "PIA-Chile";
-          uuid = "d433b7f9-e6f3-459a-a888-934c43ac9e2e";
-          remote = "santiago.privacy.network 1197 udp";
-        };
-        PIA-China = {
-          id = "PIA-China";
-          uuid = "0bb3583b-c941-4739-9d1c-bf3772a860a7";
-          remote = "china.privacy.network 1197 udp";
-        };
-        PIA-Colombia = {
-          id = "PIA-Colombia";
-          uuid = "94f2008d-2e72-4ee2-9500-bf5013cc052b";
-          remote = "bogota.privacy.network 1197 udp";
-        };
-        PIA-Costa_Rica = {
-          id = "PIA-Costa Rica";
-          uuid = "c1aff1f0-915e-44fe-8ee1-ebc572f4ce96";
-          remote = "sanjose.privacy.network 1197 udp";
-        };
-        PIA-Croatia = {
-          id = "PIA-Croatia";
-          uuid = "02772e9b-3c82-4f27-b942-fb81e0c37809";
-          remote = "zagreb.privacy.network 1197 udp";
-        };
-        PIA-Cyprus = {
-          id = "PIA-Cyprus";
-          uuid = "15851ff0-9115-49bd-8ad3-c7e1c628e351";
-          remote = "cyprus.privacy.network 1197 udp";
-        };
-        PIA-Czech_Republic = {
-          id = "PIA-Czech Republic";
-          uuid = "3606eaa0-2154-4597-94d5-3cc0b6945a47";
-          remote = "czech.privacy.network 1197 udp";
-        };
-        PIA-DE_Berlin = {
-          id = "PIA-DE Berlin";
-          uuid = "00177a44-9864-4ab5-b906-ca911d0f5ffd";
-          remote = "de-berlin.privacy.network 1197 udp";
-        };
-        PIA-DE_Frankfurt = {
-          id = "PIA-DE Frankfurt";
-          uuid = "ecb3183f-3169-47f8-b721-b7fa2ed174c3";
-          remote = "de-frankfurt.privacy.network 1197 udp";
-        };
-        PIA-DE_Germany_Streaming_Optimized = {
-          id = "PIA-DE Germany Streaming Optimized";
-          uuid = "c999dfcd-436f-4747-be92-08ae35baf6e3";
-          remote = "de-germany-so.privacy.network 1197 udp";
-        };
-        PIA-DK_Copenhagen = {
-          id = "PIA-DK Copenhagen";
-          uuid = "bed85b91-43a7-4437-bb85-bec61cda823a";
-          remote = "denmark.privacy.network 1197 udp";
-        };
-        PIA-DK_Streaming_Optimized = {
-          id = "PIA-DK Streaming Optimized";
-          uuid = "66f482c5-5f1d-4b23-92f9-70b33b469a17";
-          remote = "denmark-2.privacy.network 1197 udp";
-        };
-        PIA-Ecuador = {
-          id = "PIA-Ecuador";
-          uuid = "12590a91-2521-474d-b3de-13dcd18e7d57";
-          remote = "ec-ecuador-pf.privacy.network 1197 udp";
-        };
-        PIA-Egypt = {
-          id = "PIA-Egypt";
-          uuid = "2b0a76d9-7c72-4573-922e-329b1f9ede53";
-          remote = "egypt.privacy.network 1197 udp";
-        };
-        PIA-ES_Madrid = {
-          id = "PIA-ES Madrid";
-          uuid = "85f27080-12e0-48b0-a52b-55d6b5687ff8";
-          remote = "spain.privacy.network 1197 udp";
-        };
-        PIA-ES_Valencia = {
-          id = "PIA-ES Valencia";
-          uuid = "505c7f40-e274-4888-ad5a-014dedd372ec";
-          remote = "es-valencia.privacy.network 1197 udp";
-        };
-        PIA-Estonia = {
-          id = "PIA-Estonia";
-          uuid = "da3cc190-5b49-4b80-b277-ebbf89e7c7ec";
-          remote = "ee.privacy.network 1197 udp";
-        };
-        PIA-FI_Helsinki = {
-          id = "PIA-FI Helsinki";
-          uuid = "adb37518-ea24-420c-9419-5b6d89721acb";
-          remote = "fi.privacy.network 1197 udp";
-        };
-        PIA-FI_Streaming_Optimized = {
-          id = "PIA-FI Streaming Optimized";
-          uuid = "bcbbd96a-ab8b-4b9c-9b8a-46b0f0886777";
-          remote = "fi-2.privacy.network 1197 udp";
-        };
-        PIA-France = {
-          id = "PIA-France";
-          uuid = "1041952f-2077-4c00-aab4-b255bc8a566a";
-          remote = "france.privacy.network 1197 udp";
-        };
-        PIA-Georgia = {
-          id = "PIA-Georgia";
-          uuid = "f1b5c712-cefc-4bba-b600-94f7a49bd106";
-          remote = "georgia.privacy.network 1197 udp";
-        };
-        PIA-Greece = {
-          id = "PIA-Greece";
-          uuid = "1855cf7d-a18c-4451-87af-b4f1c287c2e3";
-          remote = "gr.privacy.network 1197 udp";
-        };
-        PIA-Greenland = {
-          id = "PIA-Greenland";
-          uuid = "ab6ebb14-d06e-45d7-8210-ba81d2f22bad";
-          remote = "greenland.privacy.network 1197 udp";
-        };
-        PIA-Guatemala = {
-          id = "PIA-Guatemala";
-          uuid = "af39b949-c331-4bd8-9c84-9233eb0ef4b5";
-          remote = "gt-guatemala-pf.privacy.network 1197 udp";
-        };
-        PIA-Hong_Kong = {
-          id = "PIA-Hong Kong";
-          uuid = "70ed930d-8d5a-402d-bda7-5594eaf078af";
-          remote = "hk.privacy.network 1197 udp";
-        };
-        PIA-Hungary = {
-          id = "PIA-Hungary";
-          uuid = "370facc6-eabb-4896-9451-ce613cb51d5f";
-          remote = "hungary.privacy.network 1197 udp";
-        };
-        PIA-Iceland = {
-          id = "PIA-Iceland";
-          uuid = "e3642404-1410-48f9-9627-4353dfb29e33";
-          remote = "is.privacy.network 1197 udp";
-        };
-        PIA-India = {
-          id = "PIA-India";
-          uuid = "a699021a-7a1f-488e-bb94-8762adbca3da";
-          remote = "in.privacy.network 1197 udp";
-        };
-        PIA-Indonesia = {
-          id = "PIA-Indonesia";
-          uuid = "79e7e205-6327-4a19-a055-f168c3a4d409";
-          remote = "jakarta.privacy.network 1197 udp";
-        };
-        PIA-Ireland = {
-          id = "PIA-Ireland";
-          uuid = "8c52c111-75e7-472f-9245-1b3d27f71482";
-          remote = "ireland.privacy.network 1197 udp";
-        };
-        PIA-Isle_of_Man = {
-          id = "PIA-Isle of Man";
-          uuid = "94cc6d81-ae9e-472a-84fd-9255785506dd";
-          remote = "man.privacy.network 1197 udp";
-        };
-        PIA-Israel = {
-          id = "PIA-Israel";
-          uuid = "77a33633-a744-4975-9d11-67b2303dfd4e";
-          remote = "israel.privacy.network 1197 udp";
-        };
-        PIA-IT_Milano = {
-          id = "PIA-IT Milano";
-          uuid = "e8ec0a72-8c3f-4616-875c-8152737c4b5c";
-          remote = "italy.privacy.network 1197 udp";
-        };
-        PIA-IT_Streaming_Optimized = {
-          id = "PIA-IT Streaming Optimized";
-          uuid = "8a708fb2-7236-456d-8fd6-5d5d984980b1";
-          remote = "italy-2.privacy.network 1197 udp";
-        };
-        PIA-JP_Streaming_Optimized = {
-          id = "PIA-JP Streaming Optimized";
-          uuid = "b8c22ab9-6778-4a5e-ab7f-9e1210c813cb";
-          remote = "japan-2.privacy.network 1197 udp";
-        };
-        PIA-JP_Tokyo = {
-          id = "PIA-JP Tokyo";
-          uuid = "b6dd8ab0-27b5-4af1-b5ec-00d21cbc8776";
-          remote = "japan.privacy.network 1197 udp";
-        };
-        PIA-Kazakhstan = {
-          id = "PIA-Kazakhstan";
-          uuid = "098ede11-8a20-49ab-ab70-46ee72cf06bc";
-          remote = "kazakhstan.privacy.network 1197 udp";
-        };
-        PIA-Latvia = {
-          id = "PIA-Latvia";
-          uuid = "91e6a3cb-3c5e-4d6b-9e81-06d5e4a67111";
-          remote = "lv.privacy.network 1197 udp";
-        };
-        PIA-Liechtenstein = {
-          id = "PIA-Liechtenstein";
-          uuid = "2bbfebee-ed9b-4610-b296-832f4f4c7324";
-          remote = "liechtenstein.privacy.network 1197 udp";
-        };
-        PIA-Lithuania = {
-          id = "PIA-Lithuania";
-          uuid = "0c428399-82b1-4c76-afff-2318c727419c";
-          remote = "lt.privacy.network 1197 udp";
-        };
-        PIA-Luxembourg = {
-          id = "PIA-Luxembourg";
-          uuid = "7ad88b77-b6e6-4a69-80f7-61baef7cfb20";
-          remote = "lu.privacy.network 1197 udp";
-        };
-        PIA-Macao = {
-          id = "PIA-Macao";
-          uuid = "2eb9e82e-ef0d-4827-a8b1-b50eea090888";
-          remote = "macau.privacy.network 1197 udp";
-        };
-        PIA-Malaysia = {
-          id = "PIA-Malaysia";
-          uuid = "bcf98b31-248d-4b45-b222-da10125b9f05";
-          remote = "kualalumpur.privacy.network 1197 udp";
-        };
-        PIA-Malta = {
-          id = "PIA-Malta";
-          uuid = "8bce1a14-8827-437b-b385-6f435d4a251f";
-          remote = "malta.privacy.network 1197 udp";
-        };
-        PIA-Mexico = {
-          id = "PIA-Mexico";
-          uuid = "d2820eda-7bb2-4b5d-8d29-aa96db8d4506";
-          remote = "mexico.privacy.network 1197 udp";
-        };
-        PIA-Moldova = {
-          id = "PIA-Moldova";
-          uuid = "5bff2d4e-c0ea-4ed6-9a7f-c898e18afae3";
-          remote = "md.privacy.network 1197 udp";
-        };
-        PIA-Monaco = {
-          id = "PIA-Monaco";
-          uuid = "08550f82-c7de-4a8b-891f-672f9a0f8804";
-          remote = "monaco.privacy.network 1197 udp";
-        };
-        PIA-Mongolia = {
-          id = "PIA-Mongolia";
-          uuid = "cef99919-0bf4-401f-9d5b-5424f3004a48";
-          remote = "mongolia.privacy.network 1197 udp";
-        };
-        PIA-Montenegro = {
-          id = "PIA-Montenegro";
-          uuid = "568c46c7-ebb3-42c9-b8da-033d1fbc4040";
-          remote = "montenegro.privacy.network 1197 udp";
-        };
-        PIA-Morocco = {
-          id = "PIA-Morocco";
-          uuid = "17d59b2e-3b6e-4ece-a491-7c7f4cb07b19";
-          remote = "morocco.privacy.network 1197 udp";
-        };
-        PIA-Nepal = {
-          id = "PIA-Nepal";
-          uuid = "90939b8e-e987-48cd-9097-493f64a32ef8";
-          remote = "np-nepal-pf.privacy.network 1197 udp";
-        };
-        PIA-Netherlands = {
-          id = "PIA-Netherlands";
-          uuid = "829e4f26-fde3-4be0-ad5b-0ccc40754eb0";
-          remote = "nl-amsterdam.privacy.network 1197 udp";
-        };
-        PIA-New_Zealand = {
-          id = "PIA-New Zealand";
-          uuid = "3de53b94-d325-4fd8-b208-47300ef6a621";
-          remote = "nz.privacy.network 1197 udp";
-        };
-        PIA-Nigeria = {
-          id = "PIA-Nigeria";
-          uuid = "c8494722-8f29-483a-b117-01c846c64c0f";
-          remote = "nigeria.privacy.network 1197 udp";
-        };
-        PIA-NL_Netherlands_Streaming_Optimized = {
-          id = "PIA-NL Netherlands Streaming Optimized";
-          uuid = "c4584ce6-be97-4bb1-b951-705d9b7ca93d";
-          remote = "nl-netherlands-so.privacy.network 1197 udp";
-        };
-        PIA-North_Macedonia = {
-          id = "PIA-North Macedonia";
-          uuid = "cd740471-9586-494b-92fe-0f41d1d2d35a";
-          remote = "mk.privacy.network 1197 udp";
-        };
-        PIA-Norway = {
-          id = "PIA-Norway";
-          uuid = "d0e54b81-2d85-4a3e-9a9a-0f7d22296ac8";
-          remote = "no.privacy.network 1197 udp";
-        };
-        PIA-Panama = {
-          id = "PIA-Panama";
-          uuid = "17067a24-7fb6-45e2-9981-c9a99ca0f64b";
-          remote = "panama.privacy.network 1197 udp";
-        };
-        PIA-Peru = {
-          id = "PIA-Peru";
-          uuid = "c5bbe73e-7d64-4450-b67f-0c546d1e8e60";
-          remote = "pe-peru-pf.privacy.network 1197 udp";
-        };
-        PIA-Philippines = {
-          id = "PIA-Philippines";
-          uuid = "e46ac1f7-5732-4634-9ce0-3585beef07b7";
-          remote = "philippines.privacy.network 1197 udp";
-        };
-        PIA-Poland = {
-          id = "PIA-Poland";
-          uuid = "0b106c8f-b071-4bf8-8d31-02c64329a9d2";
-          remote = "poland.privacy.network 1197 udp";
-        };
-        PIA-Portugal = {
-          id = "PIA-Portugal";
-          uuid = "0ff27a11-7ccd-4df9-9507-5e38f4f153fc";
-          remote = "pt.privacy.network 1197 udp";
-        };
-        PIA-Qatar = {
-          id = "PIA-Qatar";
-          uuid = "d58a2110-1879-4ffb-9a2a-e2f9a9e58c20";
-          remote = "qatar.privacy.network 1197 udp";
-        };
-        PIA-Romania = {
-          id = "PIA-Romania";
-          uuid = "bfe4248c-d6e6-4fce-b701-8f62ec96dd8f";
-          remote = "ro.privacy.network 1197 udp";
-        };
-        PIA-Saudi_Arabia = {
-          id = "PIA-Saudi Arabia";
-          uuid = "8f527741-8e50-4aa8-8d49-df25a2206171";
-          remote = "saudiarabia.privacy.network 1197 udp";
-        };
-        PIA-SE_Stockholm = {
-          id = "PIA-SE Stockholm";
-          uuid = "faa48b40-df48-4e94-9d89-34593f91c955";
-          remote = "sweden.privacy.network 1197 udp";
-        };
-        PIA-SE_Streaming_Optimized = {
-          id = "PIA-SE Streaming Optimized";
-          uuid = "b21765da-3754-4e9b-a9cc-cdb2c9733228";
-          remote = "sweden-2.privacy.network 1197 udp";
-        };
-        PIA-Serbia = {
-          id = "PIA-Serbia";
-          uuid = "5f9f341f-213b-4de0-89eb-af7a3cddaaba";
-          remote = "rs.privacy.network 1197 udp";
-        };
-        PIA-Singapore = {
-          id = "PIA-Singapore";
-          uuid = "7b7f81d5-105e-4710-9655-ee4c18def4e7";
-          remote = "sg.privacy.network 1197 udp";
-        };
-        PIA-Slovakia = {
-          id = "PIA-Slovakia";
-          uuid = "b93e0e0b-1604-4b90-8eb4-04ab73a8db44";
-          remote = "sk.privacy.network 1197 udp";
-        };
-        PIA-Slovenia = {
-          id = "PIA-Slovenia";
-          uuid = "e5016fb1-bf70-49de-b0a8-2416c267c0e2";
-          remote = "slovenia.privacy.network 1197 udp";
-        };
-        PIA-South_Africa = {
-          id = "PIA-South Africa";
-          uuid = "7311c40c-5060-44af-8626-96b68a2c6b08";
-          remote = "za.privacy.network 1197 udp";
-        };
-        PIA-South_Korea = {
-          id = "PIA-South Korea";
-          uuid = "addcd0d4-0ba8-473e-a9a8-7cac64c14fcc";
-          remote = "kr-south-korea-pf.privacy.network 1197 udp";
-        };
-        PIA-Sri_Lanka = {
-          id = "PIA-Sri Lanka";
-          uuid = "cd1492eb-882a-47e4-9309-c0aefe7b2736";
-          remote = "srilanka.privacy.network 1197 udp";
-        };
-        PIA-Switzerland = {
-          id = "PIA-Switzerland";
-          uuid = "9886816a-1a34-4e7d-9093-63ac2a16dfe5";
-          remote = "swiss.privacy.network 1197 udp";
-        };
-        PIA-Taiwan = {
-          id = "PIA-Taiwan";
-          uuid = "a30e71b6-03d4-4797-82dc-5ad1e44a8f44";
-          remote = "taiwan.privacy.network 1197 udp";
-        };
-        PIA-Turkey = {
-          id = "PIA-Turkey";
-          uuid = "352470e7-e509-464b-a0bd-7aed935bc595";
-          remote = "tr.privacy.network 1197 udp";
-        };
-        PIA-UK_London = {
-          id = "PIA-UK London";
-          uuid = "1dcf9765-4c53-4f52-a61d-05627c7cb865";
-          remote = "uk-london.privacy.network 1197 udp";
-        };
-        PIA-UK_Manchester = {
-          id = "PIA-UK Manchester";
-          uuid = "334fb332-7aad-4b75-80e1-0ad41e792bb8";
-          remote = "uk-manchester.privacy.network 1197 udp";
-        };
-        PIA-UK_Southampton = {
-          id = "PIA-UK Southampton";
-          uuid = "326b9b46-a3ac-436c-ac7c-0a9e5da4d7cb";
-          remote = "uk-southampton.privacy.network 1197 udp";
-        };
-        PIA-UK_Streaming_Optimized = {
-          id = "PIA-UK Streaming Optimized";
-          uuid = "86c1ce6e-1d9d-4d97-b50c-afcb9d23ef12";
-          remote = "uk-2.privacy.network 1197 udp";
-        };
-        PIA-Ukraine = {
-          id = "PIA-Ukraine";
-          uuid = "374596f1-2f21-45ea-b5dd-819e705a5161";
-          remote = "ua.privacy.network 1197 udp";
-        };
-        PIA-United_Arab_Emirates = {
-          id = "PIA-United Arab Emirates";
-          uuid = "4d6eb06d-6dff-4661-9d9c-a32819996b05";
-          remote = "ae.privacy.network 1197 udp";
-        };
-        PIA-Uruguay = {
-          id = "PIA-Uruguay";
-          uuid = "6de0febb-4667-4dff-8981-7cb297f3fafb";
-          remote = "uy-uruguay-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Alabama = {
-          id = "PIA-US Alabama";
-          uuid = "e7898163-ae2c-4820-898b-cc0e27fa13c3";
-          remote = "us-alabama-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Alaska = {
-          id = "PIA-US Alaska";
-          uuid = "f0aae700-d151-476d-91a4-94bd3f165b78";
-          remote = "us-alaska-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Atlanta = {
-          id = "PIA-US Atlanta";
-          uuid = "ee3ce4b0-8587-4397-8d68-d0054999b763";
-          remote = "us-atlanta.privacy.network 1197 udp";
-        };
-        PIA-US_Baltimore = {
-          id = "PIA-US Baltimore";
-          uuid = "6179b6c0-c288-4da4-9ad5-6af6e4455943";
-          remote = "us-baltimore.privacy.network 1197 udp";
-        };
-        PIA-US_California = {
-          id = "PIA-US California";
-          uuid = "c55318e2-f1c4-4870-902e-1be63249aec5";
-          remote = "us-california.privacy.network 1197 udp";
-        };
-        PIA-US_Chicago = {
-          id = "PIA-US Chicago";
-          uuid = "3a2f2285-f559-4957-b0e8-d41c109daf52";
-          remote = "us-chicago.privacy.network 1197 udp";
-        };
-        PIA-US_Connecticut = {
-          id = "PIA-US Connecticut";
-          uuid = "9e70ddaa-6690-4233-86e5-f7c47591fab0";
-          remote = "us-connecticut-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Denver = {
-          id = "PIA-US Denver";
-          uuid = "5113ac4d-7316-41b6-890e-d4fdd03b3b35";
-          remote = "us-denver.privacy.network 1197 udp";
-        };
-        PIA-US_East = {
-          id = "PIA-US East";
-          uuid = "31546613-15d3-4b2a-a925-a5de40af3f7e";
-          remote = "us-newjersey.privacy.network 1197 udp";
-        };
-        PIA-US_East_Streaming_Optimized = {
-          id = "PIA-US East Streaming Optimized";
-          uuid = "b4f3df8d-91c5-435b-b7d1-6f7e1c00d358";
-          remote = "us-streaming.privacy.network 1197 udp";
-        };
-        PIA-US_Florida = {
-          id = "PIA-US Florida";
-          uuid = "f548153b-284b-4583-94f1-6fd5c305a018";
-          remote = "us-florida.privacy.network 1197 udp";
-        };
-        PIA-US_Honolulu = {
-          id = "PIA-US Honolulu";
-          uuid = "79ce6dd2-b621-4332-8657-d811b585c638";
-          remote = "us-honolulu.privacy.network 1197 udp";
-        };
-        PIA-US_Houston = {
-          id = "PIA-US Houston";
-          uuid = "bd481d23-9c33-449a-b731-57049d9ed808";
-          remote = "us-houston.privacy.network 1197 udp";
-        };
-        PIA-US_Idaho = {
-          id = "PIA-US Idaho";
-          uuid = "54efa19f-7f63-4b6b-b264-5ff4055be877";
-          remote = "us-idaho-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Indiana = {
-          id = "PIA-US Indiana";
-          uuid = "3a963933-7880-495b-828f-a350145c8310";
-          remote = "us-indiana-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Iowa = {
-          id = "PIA-US Iowa";
-          uuid = "037c50c8-6c6a-4b86-87c2-3cad7c186c92";
-          remote = "us-iowa-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Kansas = {
-          id = "PIA-US Kansas";
-          uuid = "8d8c504b-0e56-4e5b-b1ef-331b0cd42a88";
-          remote = "us-kansas-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Kentucky = {
-          id = "PIA-US Kentucky";
-          uuid = "4c7a27cc-7acc-42be-8b13-dafd1cf970ea";
-          remote = "us-kentucky-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Las_Vegas = {
-          id = "PIA-US Las Vegas";
-          uuid = "1bfb5546-0cf1-4291-8ae8-cff4fa2be1b9";
-          remote = "us-lasvegas.privacy.network 1197 udp";
-        };
-        PIA-US_Maine = {
-          id = "PIA-US Maine";
-          uuid = "9b5f5d62-9c77-42b8-b8c0-e28b647ab1b5";
-          remote = "us-maine-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Massachusetts = {
-          id = "PIA-US Massachusetts";
-          uuid = "6ab9319b-af11-4ddf-b966-00f89c38fbbf";
-          remote = "us-massachusetts-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Michigan = {
-          id = "PIA-US Michigan";
-          uuid = "b851e530-7c03-4bfb-997a-519fb7e0da7d";
-          remote = "us-michigan-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Minnesota = {
-          id = "PIA-US Minnesota";
-          uuid = "9fffad8f-4917-4315-914e-4f2ff50d0cff";
-          remote = "us-minnesota-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Mississippi = {
-          id = "PIA-US Mississippi";
-          uuid = "d192e8ee-ef33-4ba9-aae1-bf89a9cc7349";
-          remote = "us-mississippi-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Missouri = {
-          id = "PIA-US Missouri";
-          uuid = "2d2b11d8-e62b-4364-891b-7e50ca922392";
-          remote = "us-missouri-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Montana = {
-          id = "PIA-US Montana";
-          uuid = "4158658a-c692-45ef-a9f7-bdae419bb9d3";
-          remote = "us-montana-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Nebraska = {
-          id = "PIA-US Nebraska";
-          uuid = "a6f06fbb-a800-4919-93e5-bb9a16daa95b";
-          remote = "us-nebraska-pf.privacy.network 1197 udp";
-        };
-        PIA-US_New_Hampshire = {
-          id = "PIA-US New Hampshire";
-          uuid = "6f1de4c0-cfae-4076-b5a6-8ca9cc3692dd";
-          remote = "us-new-hampshire-pf.privacy.network 1197 udp";
-        };
-        PIA-US_New_Mexico = {
-          id = "PIA-US New Mexico";
-          uuid = "4a5c9eb7-5c48-4fc0-95d8-90cb52980c5a";
-          remote = "us-new-mexico-pf.privacy.network 1197 udp";
-        };
-        PIA-US_New_York = {
-          id = "PIA-US New York";
-          uuid = "0b22b9ac-62d6-4281-bf06-164897425a8a";
-          remote = "us-newyorkcity.privacy.network 1197 udp";
-        };
-        PIA-US_North_Carolina = {
-          id = "PIA-US North Carolina";
-          uuid = "f7cc5b75-f187-4094-a8b0-0b1cd49cff33";
-          remote = "us-north-carolina-pf.privacy.network 1197 udp";
-        };
-        PIA-US_North_Dakota = {
-          id = "PIA-US North Dakota";
-          uuid = "9ac6bfcc-025f-4f6a-bba3-239dae83fd01";
-          remote = "us-north-dakota-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Ohio = {
-          id = "PIA-US Ohio";
-          uuid = "e4cd9166-d19e-4f36-af98-4e9d03f8da90";
-          remote = "us-ohio-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Oklahoma = {
-          id = "PIA-US Oklahoma";
-          uuid = "648a8ecc-0243-4afa-a4dc-62d02ef87b93";
-          remote = "us-oklahoma-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Oregon = {
-          id = "PIA-US Oregon";
-          uuid = "78b9ddb5-45f1-48a8-9a01-2766d5f940d4";
-          remote = "us-oregon-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Pennsylvania = {
-          id = "PIA-US Pennsylvania";
-          uuid = "02e3387e-d86d-4290-a800-92b12fa57bac";
-          remote = "us-pennsylvania-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Rhode_Island = {
-          id = "PIA-US Rhode Island";
-          uuid = "29a8371c-1ab6-4af7-9c54-1b2a75811773";
-          remote = "us-rhode-island-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Salt_Lake_City = {
-          id = "PIA-US Salt Lake City";
-          uuid = "e9b8aef8-5b53-4849-8056-aaa3cfaca916";
-          remote = "us-saltlakecity.privacy.network 1197 udp";
-        };
-        PIA-US_Seattle = {
-          id = "PIA-US Seattle";
-          uuid = "7b6bc52f-870b-4e17-9e95-8237b9be0094";
-          remote = "us-seattle.privacy.network 1197 udp";
-        };
-        PIA-US_Silicon_Valley = {
-          id = "PIA-US Silicon Valley";
-          uuid = "4ba7b32d-c1cd-4b97-8594-fcb430d803cc";
-          remote = "us-siliconvalley.privacy.network 1197 udp";
-        };
-        PIA-US_South_Carolina = {
-          id = "PIA-US South Carolina";
-          uuid = "43a9f6e5-100c-480c-bf7b-793a3424fa2f";
-          remote = "us-south-carolina-pf.privacy.network 1197 udp";
-        };
-        PIA-US_South_Dakota = {
-          id = "PIA-US South Dakota";
-          uuid = "14797740-9f99-48c2-8c28-f86e48ee2279";
-          remote = "us-south-dakota-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Tennessee = {
-          id = "PIA-US Tennessee";
-          uuid = "35ed88c5-5414-4c0f-96a1-8e2359cb639b";
-          remote = "us-tennessee-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Texas = {
-          id = "PIA-US Texas";
-          uuid = "81d51b51-ac2a-4b2b-b042-53945b7352c3";
-          remote = "us-texas.privacy.network 1197 udp";
-        };
-        PIA-US_Vermont = {
-          id = "PIA-US Vermont";
-          uuid = "414ee06b-276e-479a-b07d-1913da366e96";
-          remote = "us-vermont-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Virginia = {
-          id = "PIA-US Virginia";
-          uuid = "3422b133-e163-40a4-9bed-04de08c06b19";
-          remote = "us-virginia-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Washington_DC = {
-          id = "PIA-US Washington DC";
-          uuid = "c0fa3733-57fc-4e7e-899f-50994d4a6157";
-          remote = "us-washingtondc.privacy.network 1197 udp";
-        };
-        PIA-US_West = {
-          id = "PIA-US West";
-          uuid = "1d7f4ebd-2758-4807-886b-8190550db374";
-          remote = "us3.privacy.network 1197 udp";
-        };
-        PIA-US_West_Streaming_Optimized = {
-          id = "PIA-US West Streaming Optimized";
-          uuid = "9b67301c-ea3b-4c39-9f38-9c2763201475";
-          remote = "us-streaming-2.privacy.network 1197 udp";
-        };
-        PIA-US_West_Virginia = {
-          id = "PIA-US West Virginia";
-          uuid = "96c69877-ac54-4dbb-a2bb-43fd72994249";
-          remote = "us-west-virginia-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Wilmington = {
-          id = "PIA-US Wilmington";
-          uuid = "eb6273e2-d88d-4498-b75f-b6470b1129d7";
-          remote = "us-wilmington.privacy.network 1197 udp";
-        };
-        PIA-US_Wisconsin = {
-          id = "PIA-US Wisconsin";
-          uuid = "52764382-f5af-4ce0-9655-6f26eb909cd1";
-          remote = "us-wisconsin-pf.privacy.network 1197 udp";
-        };
-        PIA-US_Wyoming = {
-          id = "PIA-US Wyoming";
-          uuid = "ea2dff72-9003-4c87-a953-c09219a5a9ed";
-          remote = "us-wyoming-pf.privacy.network 1197 udp";
-        };
-        PIA-Venezuela = {
-          id = "PIA-Venezuela";
-          uuid = "5b25f469-e2bf-41b2-803c-7179ca86bfef";
-          remote = "venezuela.privacy.network 1197 udp";
-        };
-        PIA-Vietnam = {
-          id = "PIA-Vietnam";
-          uuid = "f5136c30-e8f6-4b17-a48a-4874b7b7f660";
-          remote = "vietnam.privacy.network 1197 udp";
-        };
+  PIA-Albania = {
+    id = "PIA-Albania";
+    uuid = "379fa9ce-746c-4866-9523-41f0e512a3ef";
+    remote = "al.privacy.network 1197 udp";
+  };
+  PIA-Algeria = {
+    id = "PIA-Algeria";
+    uuid = "18bd03e0-8203-4a82-aa97-d63bf436563e";
+    remote = "dz.privacy.network 1197 udp";
+  };
+  PIA-Andorra = {
+    id = "PIA-Andorra";
+    uuid = "9509721c-7411-4161-a1e9-b1c4e0fdc34e";
+    remote = "ad.privacy.network 1197 udp";
+  };
+  PIA-Argentina = {
+    id = "PIA-Argentina";
+    uuid = "f00e17bb-b979-4921-a987-8fbb14a94cc2";
+    remote = "ar.privacy.network 1197 udp";
+  };
+  PIA-Armenia = {
+    id = "PIA-Armenia";
+    uuid = "a8fc3ab5-e60d-42cd-bbb5-e744b54950d4";
+    remote = "yerevan.privacy.network 1197 udp";
+  };
+  PIA-AU_Adelaide = {
+    id = "PIA-AU Adelaide";
+    uuid = "63df32cd-ed45-451b-8b8b-bf65f1ada31e";
+    remote = "au-adelaide-pf.privacy.network 1197 udp";
+  };
+  PIA-AU_Brisbane = {
+    id = "PIA-AU Brisbane";
+    uuid = "7330cff5-7c7c-4ace-993f-e44552e76727";
+    remote = "au-brisbane-pf.privacy.network 1197 udp";
+  };
+  PIA-AU_Melbourne = {
+    id = "PIA-AU Melbourne";
+    uuid = "a69b3e96-43ee-45e5-8b13-a00d27d9dd47";
+    remote = "aus-melbourne.privacy.network 1197 udp";
+  };
+  PIA-AU_Perth = {
+    id = "PIA-AU Perth";
+    uuid = "3819c9e9-00e7-4345-908d-785369ca1a2e";
+    remote = "aus-perth.privacy.network 1197 udp";
+  };
+  PIA-AU_Sydney = {
+    id = "PIA-AU Sydney";
+    uuid = "07cd5a3e-8d88-49d3-9ac7-696f1a955f7e";
+    remote = "au-sydney.privacy.network 1197 udp";
+  };
+  PIA-Australia_Streaming_Optimized = {
+    id = "PIA-Australia Streaming Optimized";
+    uuid = "2a1f6a07-0633-45df-9e9a-fe517895ba00";
+    remote = "au-australia-so.privacy.network 1197 udp";
+  };
+  PIA-Austria = {
+    id = "PIA-Austria";
+    uuid = "38ecd6fa-e7ea-4fb7-8e97-c8fcea7764a8";
+    remote = "austria.privacy.network 1197 udp";
+  };
+  PIA-Bahamas = {
+    id = "PIA-Bahamas";
+    uuid = "36f48c2c-fbcd-4457-974b-3baef64df0aa";
+    remote = "bahamas.privacy.network 1197 udp";
+  };
+  PIA-Bangladesh = {
+    id = "PIA-Bangladesh";
+    uuid = "72e23bb7-6f6d-4eae-a657-b6bd1fc6729a";
+    remote = "bangladesh.privacy.network 1197 udp";
+  };
+  PIA-Belgium = {
+    id = "PIA-Belgium";
+    uuid = "b2739182-2fe7-49f2-a800-c5525b188246";
+    remote = "brussels.privacy.network 1197 udp";
+  };
+  PIA-Bolivia = {
+    id = "PIA-Bolivia";
+    uuid = "994e32dc-74a5-40f1-a0bb-93e736d71e12";
+    remote = "bo-bolivia-pf.privacy.network 1197 udp";
+  };
+  PIA-Bosnia_and_Herzegovina = {
+    id = "PIA-Bosnia and Herzegovina";
+    uuid = "ab894ba3-7cf5-4dbd-9e60-4bd0554205e3";
+    remote = "ba.privacy.network 1197 udp";
+  };
+  PIA-Brazil = {
+    id = "PIA-Brazil";
+    uuid = "75e09ea2-27e1-4215-abf5-c8e363fa0366";
+    remote = "br.privacy.network 1197 udp";
+  };
+  PIA-Bulgaria = {
+    id = "PIA-Bulgaria";
+    uuid = "f97a0639-b3b5-4d39-9635-72c3d23c7989";
+    remote = "sofia.privacy.network 1197 udp";
+  };
+  PIA-CA_Montreal = {
+    id = "PIA-CA Montreal";
+    uuid = "1ede4070-6c77-47f6-8562-6defb7992569";
+    remote = "ca-montreal.privacy.network 1197 udp";
+  };
+  PIA-CA_Ontario = {
+    id = "PIA-CA Ontario";
+    uuid = "fc5adbf7-3ff9-489e-b4be-f52fa9311ae6";
+    remote = "ca-ontario.privacy.network 1197 udp";
+  };
+  PIA-CA_Ontario_Streaming_Optimized = {
+    id = "PIA-CA Ontario Streaming Optimized";
+    uuid = "16a4fd69-8287-400e-bd1c-c3de14315aca";
+    remote = "ca-ontario-so.privacy.network 1197 udp";
+  };
+  PIA-CA_Toronto = {
+    id = "PIA-CA Toronto";
+    uuid = "3349f281-f269-4948-b087-84e38f27ecea";
+    remote = "ca-toronto.privacy.network 1197 udp";
+  };
+  PIA-CA_Vancouver = {
+    id = "PIA-CA Vancouver";
+    uuid = "758754cc-b3c5-4670-a93d-de75389bf3d1";
+    remote = "ca-vancouver.privacy.network 1197 udp";
+  };
+  PIA-Cambodia = {
+    id = "PIA-Cambodia";
+    uuid = "65b71305-93ce-4218-bc9d-285a86e99ab7";
+    remote = "cambodia.privacy.network 1197 udp";
+  };
+  PIA-Chile = {
+    id = "PIA-Chile";
+    uuid = "d433b7f9-e6f3-459a-a888-934c43ac9e2e";
+    remote = "santiago.privacy.network 1197 udp";
+  };
+  PIA-China = {
+    id = "PIA-China";
+    uuid = "0bb3583b-c941-4739-9d1c-bf3772a860a7";
+    remote = "china.privacy.network 1197 udp";
+  };
+  PIA-Colombia = {
+    id = "PIA-Colombia";
+    uuid = "94f2008d-2e72-4ee2-9500-bf5013cc052b";
+    remote = "bogota.privacy.network 1197 udp";
+  };
+  PIA-Costa_Rica = {
+    id = "PIA-Costa Rica";
+    uuid = "c1aff1f0-915e-44fe-8ee1-ebc572f4ce96";
+    remote = "sanjose.privacy.network 1197 udp";
+  };
+  PIA-Croatia = {
+    id = "PIA-Croatia";
+    uuid = "02772e9b-3c82-4f27-b942-fb81e0c37809";
+    remote = "zagreb.privacy.network 1197 udp";
+  };
+  PIA-Cyprus = {
+    id = "PIA-Cyprus";
+    uuid = "15851ff0-9115-49bd-8ad3-c7e1c628e351";
+    remote = "cyprus.privacy.network 1197 udp";
+  };
+  PIA-Czech_Republic = {
+    id = "PIA-Czech Republic";
+    uuid = "3606eaa0-2154-4597-94d5-3cc0b6945a47";
+    remote = "czech.privacy.network 1197 udp";
+  };
+  PIA-DE_Berlin = {
+    id = "PIA-DE Berlin";
+    uuid = "00177a44-9864-4ab5-b906-ca911d0f5ffd";
+    remote = "de-berlin.privacy.network 1197 udp";
+  };
+  PIA-DE_Frankfurt = {
+    id = "PIA-DE Frankfurt";
+    uuid = "ecb3183f-3169-47f8-b721-b7fa2ed174c3";
+    remote = "de-frankfurt.privacy.network 1197 udp";
+  };
+  PIA-DE_Germany_Streaming_Optimized = {
+    id = "PIA-DE Germany Streaming Optimized";
+    uuid = "c999dfcd-436f-4747-be92-08ae35baf6e3";
+    remote = "de-germany-so.privacy.network 1197 udp";
+  };
+  PIA-DK_Copenhagen = {
+    id = "PIA-DK Copenhagen";
+    uuid = "bed85b91-43a7-4437-bb85-bec61cda823a";
+    remote = "denmark.privacy.network 1197 udp";
+  };
+  PIA-DK_Streaming_Optimized = {
+    id = "PIA-DK Streaming Optimized";
+    uuid = "66f482c5-5f1d-4b23-92f9-70b33b469a17";
+    remote = "denmark-2.privacy.network 1197 udp";
+  };
+  PIA-Ecuador = {
+    id = "PIA-Ecuador";
+    uuid = "12590a91-2521-474d-b3de-13dcd18e7d57";
+    remote = "ec-ecuador-pf.privacy.network 1197 udp";
+  };
+  PIA-Egypt = {
+    id = "PIA-Egypt";
+    uuid = "2b0a76d9-7c72-4573-922e-329b1f9ede53";
+    remote = "egypt.privacy.network 1197 udp";
+  };
+  PIA-ES_Madrid = {
+    id = "PIA-ES Madrid";
+    uuid = "85f27080-12e0-48b0-a52b-55d6b5687ff8";
+    remote = "spain.privacy.network 1197 udp";
+  };
+  PIA-ES_Valencia = {
+    id = "PIA-ES Valencia";
+    uuid = "505c7f40-e274-4888-ad5a-014dedd372ec";
+    remote = "es-valencia.privacy.network 1197 udp";
+  };
+  PIA-Estonia = {
+    id = "PIA-Estonia";
+    uuid = "da3cc190-5b49-4b80-b277-ebbf89e7c7ec";
+    remote = "ee.privacy.network 1197 udp";
+  };
+  PIA-FI_Helsinki = {
+    id = "PIA-FI Helsinki";
+    uuid = "adb37518-ea24-420c-9419-5b6d89721acb";
+    remote = "fi.privacy.network 1197 udp";
+  };
+  PIA-FI_Streaming_Optimized = {
+    id = "PIA-FI Streaming Optimized";
+    uuid = "bcbbd96a-ab8b-4b9c-9b8a-46b0f0886777";
+    remote = "fi-2.privacy.network 1197 udp";
+  };
+  PIA-France = {
+    id = "PIA-France";
+    uuid = "1041952f-2077-4c00-aab4-b255bc8a566a";
+    remote = "france.privacy.network 1197 udp";
+  };
+  PIA-Georgia = {
+    id = "PIA-Georgia";
+    uuid = "f1b5c712-cefc-4bba-b600-94f7a49bd106";
+    remote = "georgia.privacy.network 1197 udp";
+  };
+  PIA-Greece = {
+    id = "PIA-Greece";
+    uuid = "1855cf7d-a18c-4451-87af-b4f1c287c2e3";
+    remote = "gr.privacy.network 1197 udp";
+  };
+  PIA-Greenland = {
+    id = "PIA-Greenland";
+    uuid = "ab6ebb14-d06e-45d7-8210-ba81d2f22bad";
+    remote = "greenland.privacy.network 1197 udp";
+  };
+  PIA-Guatemala = {
+    id = "PIA-Guatemala";
+    uuid = "af39b949-c331-4bd8-9c84-9233eb0ef4b5";
+    remote = "gt-guatemala-pf.privacy.network 1197 udp";
+  };
+  PIA-Hong_Kong = {
+    id = "PIA-Hong Kong";
+    uuid = "70ed930d-8d5a-402d-bda7-5594eaf078af";
+    remote = "hk.privacy.network 1197 udp";
+  };
+  PIA-Hungary = {
+    id = "PIA-Hungary";
+    uuid = "370facc6-eabb-4896-9451-ce613cb51d5f";
+    remote = "hungary.privacy.network 1197 udp";
+  };
+  PIA-Iceland = {
+    id = "PIA-Iceland";
+    uuid = "e3642404-1410-48f9-9627-4353dfb29e33";
+    remote = "is.privacy.network 1197 udp";
+  };
+  PIA-India = {
+    id = "PIA-India";
+    uuid = "a699021a-7a1f-488e-bb94-8762adbca3da";
+    remote = "in.privacy.network 1197 udp";
+  };
+  PIA-Indonesia = {
+    id = "PIA-Indonesia";
+    uuid = "79e7e205-6327-4a19-a055-f168c3a4d409";
+    remote = "jakarta.privacy.network 1197 udp";
+  };
+  PIA-Ireland = {
+    id = "PIA-Ireland";
+    uuid = "8c52c111-75e7-472f-9245-1b3d27f71482";
+    remote = "ireland.privacy.network 1197 udp";
+  };
+  PIA-Isle_of_Man = {
+    id = "PIA-Isle of Man";
+    uuid = "94cc6d81-ae9e-472a-84fd-9255785506dd";
+    remote = "man.privacy.network 1197 udp";
+  };
+  PIA-Israel = {
+    id = "PIA-Israel";
+    uuid = "77a33633-a744-4975-9d11-67b2303dfd4e";
+    remote = "israel.privacy.network 1197 udp";
+  };
+  PIA-IT_Milano = {
+    id = "PIA-IT Milano";
+    uuid = "e8ec0a72-8c3f-4616-875c-8152737c4b5c";
+    remote = "italy.privacy.network 1197 udp";
+  };
+  PIA-IT_Streaming_Optimized = {
+    id = "PIA-IT Streaming Optimized";
+    uuid = "8a708fb2-7236-456d-8fd6-5d5d984980b1";
+    remote = "italy-2.privacy.network 1197 udp";
+  };
+  PIA-JP_Streaming_Optimized = {
+    id = "PIA-JP Streaming Optimized";
+    uuid = "b8c22ab9-6778-4a5e-ab7f-9e1210c813cb";
+    remote = "japan-2.privacy.network 1197 udp";
+  };
+  PIA-JP_Tokyo = {
+    id = "PIA-JP Tokyo";
+    uuid = "b6dd8ab0-27b5-4af1-b5ec-00d21cbc8776";
+    remote = "japan.privacy.network 1197 udp";
+  };
+  PIA-Kazakhstan = {
+    id = "PIA-Kazakhstan";
+    uuid = "098ede11-8a20-49ab-ab70-46ee72cf06bc";
+    remote = "kazakhstan.privacy.network 1197 udp";
+  };
+  PIA-Latvia = {
+    id = "PIA-Latvia";
+    uuid = "91e6a3cb-3c5e-4d6b-9e81-06d5e4a67111";
+    remote = "lv.privacy.network 1197 udp";
+  };
+  PIA-Liechtenstein = {
+    id = "PIA-Liechtenstein";
+    uuid = "2bbfebee-ed9b-4610-b296-832f4f4c7324";
+    remote = "liechtenstein.privacy.network 1197 udp";
+  };
+  PIA-Lithuania = {
+    id = "PIA-Lithuania";
+    uuid = "0c428399-82b1-4c76-afff-2318c727419c";
+    remote = "lt.privacy.network 1197 udp";
+  };
+  PIA-Luxembourg = {
+    id = "PIA-Luxembourg";
+    uuid = "7ad88b77-b6e6-4a69-80f7-61baef7cfb20";
+    remote = "lu.privacy.network 1197 udp";
+  };
+  PIA-Macao = {
+    id = "PIA-Macao";
+    uuid = "2eb9e82e-ef0d-4827-a8b1-b50eea090888";
+    remote = "macau.privacy.network 1197 udp";
+  };
+  PIA-Malaysia = {
+    id = "PIA-Malaysia";
+    uuid = "bcf98b31-248d-4b45-b222-da10125b9f05";
+    remote = "kualalumpur.privacy.network 1197 udp";
+  };
+  PIA-Malta = {
+    id = "PIA-Malta";
+    uuid = "8bce1a14-8827-437b-b385-6f435d4a251f";
+    remote = "malta.privacy.network 1197 udp";
+  };
+  PIA-Mexico = {
+    id = "PIA-Mexico";
+    uuid = "d2820eda-7bb2-4b5d-8d29-aa96db8d4506";
+    remote = "mexico.privacy.network 1197 udp";
+  };
+  PIA-Moldova = {
+    id = "PIA-Moldova";
+    uuid = "5bff2d4e-c0ea-4ed6-9a7f-c898e18afae3";
+    remote = "md.privacy.network 1197 udp";
+  };
+  PIA-Monaco = {
+    id = "PIA-Monaco";
+    uuid = "08550f82-c7de-4a8b-891f-672f9a0f8804";
+    remote = "monaco.privacy.network 1197 udp";
+  };
+  PIA-Mongolia = {
+    id = "PIA-Mongolia";
+    uuid = "cef99919-0bf4-401f-9d5b-5424f3004a48";
+    remote = "mongolia.privacy.network 1197 udp";
+  };
+  PIA-Montenegro = {
+    id = "PIA-Montenegro";
+    uuid = "568c46c7-ebb3-42c9-b8da-033d1fbc4040";
+    remote = "montenegro.privacy.network 1197 udp";
+  };
+  PIA-Morocco = {
+    id = "PIA-Morocco";
+    uuid = "17d59b2e-3b6e-4ece-a491-7c7f4cb07b19";
+    remote = "morocco.privacy.network 1197 udp";
+  };
+  PIA-Nepal = {
+    id = "PIA-Nepal";
+    uuid = "90939b8e-e987-48cd-9097-493f64a32ef8";
+    remote = "np-nepal-pf.privacy.network 1197 udp";
+  };
+  PIA-Netherlands = {
+    id = "PIA-Netherlands";
+    uuid = "829e4f26-fde3-4be0-ad5b-0ccc40754eb0";
+    remote = "nl-amsterdam.privacy.network 1197 udp";
+  };
+  PIA-New_Zealand = {
+    id = "PIA-New Zealand";
+    uuid = "3de53b94-d325-4fd8-b208-47300ef6a621";
+    remote = "nz.privacy.network 1197 udp";
+  };
+  PIA-Nigeria = {
+    id = "PIA-Nigeria";
+    uuid = "c8494722-8f29-483a-b117-01c846c64c0f";
+    remote = "nigeria.privacy.network 1197 udp";
+  };
+  PIA-NL_Netherlands_Streaming_Optimized = {
+    id = "PIA-NL Netherlands Streaming Optimized";
+    uuid = "c4584ce6-be97-4bb1-b951-705d9b7ca93d";
+    remote = "nl-netherlands-so.privacy.network 1197 udp";
+  };
+  PIA-North_Macedonia = {
+    id = "PIA-North Macedonia";
+    uuid = "cd740471-9586-494b-92fe-0f41d1d2d35a";
+    remote = "mk.privacy.network 1197 udp";
+  };
+  PIA-Norway = {
+    id = "PIA-Norway";
+    uuid = "d0e54b81-2d85-4a3e-9a9a-0f7d22296ac8";
+    remote = "no.privacy.network 1197 udp";
+  };
+  PIA-Panama = {
+    id = "PIA-Panama";
+    uuid = "17067a24-7fb6-45e2-9981-c9a99ca0f64b";
+    remote = "panama.privacy.network 1197 udp";
+  };
+  PIA-Peru = {
+    id = "PIA-Peru";
+    uuid = "c5bbe73e-7d64-4450-b67f-0c546d1e8e60";
+    remote = "pe-peru-pf.privacy.network 1197 udp";
+  };
+  PIA-Philippines = {
+    id = "PIA-Philippines";
+    uuid = "e46ac1f7-5732-4634-9ce0-3585beef07b7";
+    remote = "philippines.privacy.network 1197 udp";
+  };
+  PIA-Poland = {
+    id = "PIA-Poland";
+    uuid = "0b106c8f-b071-4bf8-8d31-02c64329a9d2";
+    remote = "poland.privacy.network 1197 udp";
+  };
+  PIA-Portugal = {
+    id = "PIA-Portugal";
+    uuid = "0ff27a11-7ccd-4df9-9507-5e38f4f153fc";
+    remote = "pt.privacy.network 1197 udp";
+  };
+  PIA-Qatar = {
+    id = "PIA-Qatar";
+    uuid = "d58a2110-1879-4ffb-9a2a-e2f9a9e58c20";
+    remote = "qatar.privacy.network 1197 udp";
+  };
+  PIA-Romania = {
+    id = "PIA-Romania";
+    uuid = "bfe4248c-d6e6-4fce-b701-8f62ec96dd8f";
+    remote = "ro.privacy.network 1197 udp";
+  };
+  PIA-Saudi_Arabia = {
+    id = "PIA-Saudi Arabia";
+    uuid = "8f527741-8e50-4aa8-8d49-df25a2206171";
+    remote = "saudiarabia.privacy.network 1197 udp";
+  };
+  PIA-SE_Stockholm = {
+    id = "PIA-SE Stockholm";
+    uuid = "faa48b40-df48-4e94-9d89-34593f91c955";
+    remote = "sweden.privacy.network 1197 udp";
+  };
+  PIA-SE_Streaming_Optimized = {
+    id = "PIA-SE Streaming Optimized";
+    uuid = "b21765da-3754-4e9b-a9cc-cdb2c9733228";
+    remote = "sweden-2.privacy.network 1197 udp";
+  };
+  PIA-Serbia = {
+    id = "PIA-Serbia";
+    uuid = "5f9f341f-213b-4de0-89eb-af7a3cddaaba";
+    remote = "rs.privacy.network 1197 udp";
+  };
+  PIA-Singapore = {
+    id = "PIA-Singapore";
+    uuid = "7b7f81d5-105e-4710-9655-ee4c18def4e7";
+    remote = "sg.privacy.network 1197 udp";
+  };
+  PIA-Slovakia = {
+    id = "PIA-Slovakia";
+    uuid = "b93e0e0b-1604-4b90-8eb4-04ab73a8db44";
+    remote = "sk.privacy.network 1197 udp";
+  };
+  PIA-Slovenia = {
+    id = "PIA-Slovenia";
+    uuid = "e5016fb1-bf70-49de-b0a8-2416c267c0e2";
+    remote = "slovenia.privacy.network 1197 udp";
+  };
+  PIA-South_Africa = {
+    id = "PIA-South Africa";
+    uuid = "7311c40c-5060-44af-8626-96b68a2c6b08";
+    remote = "za.privacy.network 1197 udp";
+  };
+  PIA-South_Korea = {
+    id = "PIA-South Korea";
+    uuid = "addcd0d4-0ba8-473e-a9a8-7cac64c14fcc";
+    remote = "kr-south-korea-pf.privacy.network 1197 udp";
+  };
+  PIA-Sri_Lanka = {
+    id = "PIA-Sri Lanka";
+    uuid = "cd1492eb-882a-47e4-9309-c0aefe7b2736";
+    remote = "srilanka.privacy.network 1197 udp";
+  };
+  PIA-Switzerland = {
+    id = "PIA-Switzerland";
+    uuid = "9886816a-1a34-4e7d-9093-63ac2a16dfe5";
+    remote = "swiss.privacy.network 1197 udp";
+  };
+  PIA-Taiwan = {
+    id = "PIA-Taiwan";
+    uuid = "a30e71b6-03d4-4797-82dc-5ad1e44a8f44";
+    remote = "taiwan.privacy.network 1197 udp";
+  };
+  PIA-Turkey = {
+    id = "PIA-Turkey";
+    uuid = "352470e7-e509-464b-a0bd-7aed935bc595";
+    remote = "tr.privacy.network 1197 udp";
+  };
+  PIA-UK_London = {
+    id = "PIA-UK London";
+    uuid = "1dcf9765-4c53-4f52-a61d-05627c7cb865";
+    remote = "uk-london.privacy.network 1197 udp";
+  };
+  PIA-UK_Manchester = {
+    id = "PIA-UK Manchester";
+    uuid = "334fb332-7aad-4b75-80e1-0ad41e792bb8";
+    remote = "uk-manchester.privacy.network 1197 udp";
+  };
+  PIA-UK_Southampton = {
+    id = "PIA-UK Southampton";
+    uuid = "326b9b46-a3ac-436c-ac7c-0a9e5da4d7cb";
+    remote = "uk-southampton.privacy.network 1197 udp";
+  };
+  PIA-UK_Streaming_Optimized = {
+    id = "PIA-UK Streaming Optimized";
+    uuid = "86c1ce6e-1d9d-4d97-b50c-afcb9d23ef12";
+    remote = "uk-2.privacy.network 1197 udp";
+  };
+  PIA-Ukraine = {
+    id = "PIA-Ukraine";
+    uuid = "374596f1-2f21-45ea-b5dd-819e705a5161";
+    remote = "ua.privacy.network 1197 udp";
+  };
+  PIA-United_Arab_Emirates = {
+    id = "PIA-United Arab Emirates";
+    uuid = "4d6eb06d-6dff-4661-9d9c-a32819996b05";
+    remote = "ae.privacy.network 1197 udp";
+  };
+  PIA-Uruguay = {
+    id = "PIA-Uruguay";
+    uuid = "6de0febb-4667-4dff-8981-7cb297f3fafb";
+    remote = "uy-uruguay-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Alabama = {
+    id = "PIA-US Alabama";
+    uuid = "e7898163-ae2c-4820-898b-cc0e27fa13c3";
+    remote = "us-alabama-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Alaska = {
+    id = "PIA-US Alaska";
+    uuid = "f0aae700-d151-476d-91a4-94bd3f165b78";
+    remote = "us-alaska-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Atlanta = {
+    id = "PIA-US Atlanta";
+    uuid = "ee3ce4b0-8587-4397-8d68-d0054999b763";
+    remote = "us-atlanta.privacy.network 1197 udp";
+  };
+  PIA-US_Baltimore = {
+    id = "PIA-US Baltimore";
+    uuid = "6179b6c0-c288-4da4-9ad5-6af6e4455943";
+    remote = "us-baltimore.privacy.network 1197 udp";
+  };
+  PIA-US_California = {
+    id = "PIA-US California";
+    uuid = "c55318e2-f1c4-4870-902e-1be63249aec5";
+    remote = "us-california.privacy.network 1197 udp";
+  };
+  PIA-US_Chicago = {
+    id = "PIA-US Chicago";
+    uuid = "3a2f2285-f559-4957-b0e8-d41c109daf52";
+    remote = "us-chicago.privacy.network 1197 udp";
+  };
+  PIA-US_Connecticut = {
+    id = "PIA-US Connecticut";
+    uuid = "9e70ddaa-6690-4233-86e5-f7c47591fab0";
+    remote = "us-connecticut-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Denver = {
+    id = "PIA-US Denver";
+    uuid = "5113ac4d-7316-41b6-890e-d4fdd03b3b35";
+    remote = "us-denver.privacy.network 1197 udp";
+  };
+  PIA-US_East = {
+    id = "PIA-US East";
+    uuid = "31546613-15d3-4b2a-a925-a5de40af3f7e";
+    remote = "us-newjersey.privacy.network 1197 udp";
+  };
+  PIA-US_East_Streaming_Optimized = {
+    id = "PIA-US East Streaming Optimized";
+    uuid = "b4f3df8d-91c5-435b-b7d1-6f7e1c00d358";
+    remote = "us-streaming.privacy.network 1197 udp";
+  };
+  PIA-US_Florida = {
+    id = "PIA-US Florida";
+    uuid = "f548153b-284b-4583-94f1-6fd5c305a018";
+    remote = "us-florida.privacy.network 1197 udp";
+  };
+  PIA-US_Honolulu = {
+    id = "PIA-US Honolulu";
+    uuid = "79ce6dd2-b621-4332-8657-d811b585c638";
+    remote = "us-honolulu.privacy.network 1197 udp";
+  };
+  PIA-US_Houston = {
+    id = "PIA-US Houston";
+    uuid = "bd481d23-9c33-449a-b731-57049d9ed808";
+    remote = "us-houston.privacy.network 1197 udp";
+  };
+  PIA-US_Idaho = {
+    id = "PIA-US Idaho";
+    uuid = "54efa19f-7f63-4b6b-b264-5ff4055be877";
+    remote = "us-idaho-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Indiana = {
+    id = "PIA-US Indiana";
+    uuid = "3a963933-7880-495b-828f-a350145c8310";
+    remote = "us-indiana-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Iowa = {
+    id = "PIA-US Iowa";
+    uuid = "037c50c8-6c6a-4b86-87c2-3cad7c186c92";
+    remote = "us-iowa-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Kansas = {
+    id = "PIA-US Kansas";
+    uuid = "8d8c504b-0e56-4e5b-b1ef-331b0cd42a88";
+    remote = "us-kansas-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Kentucky = {
+    id = "PIA-US Kentucky";
+    uuid = "4c7a27cc-7acc-42be-8b13-dafd1cf970ea";
+    remote = "us-kentucky-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Las_Vegas = {
+    id = "PIA-US Las Vegas";
+    uuid = "1bfb5546-0cf1-4291-8ae8-cff4fa2be1b9";
+    remote = "us-lasvegas.privacy.network 1197 udp";
+  };
+  PIA-US_Maine = {
+    id = "PIA-US Maine";
+    uuid = "9b5f5d62-9c77-42b8-b8c0-e28b647ab1b5";
+    remote = "us-maine-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Massachusetts = {
+    id = "PIA-US Massachusetts";
+    uuid = "6ab9319b-af11-4ddf-b966-00f89c38fbbf";
+    remote = "us-massachusetts-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Michigan = {
+    id = "PIA-US Michigan";
+    uuid = "b851e530-7c03-4bfb-997a-519fb7e0da7d";
+    remote = "us-michigan-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Minnesota = {
+    id = "PIA-US Minnesota";
+    uuid = "9fffad8f-4917-4315-914e-4f2ff50d0cff";
+    remote = "us-minnesota-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Mississippi = {
+    id = "PIA-US Mississippi";
+    uuid = "d192e8ee-ef33-4ba9-aae1-bf89a9cc7349";
+    remote = "us-mississippi-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Missouri = {
+    id = "PIA-US Missouri";
+    uuid = "2d2b11d8-e62b-4364-891b-7e50ca922392";
+    remote = "us-missouri-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Montana = {
+    id = "PIA-US Montana";
+    uuid = "4158658a-c692-45ef-a9f7-bdae419bb9d3";
+    remote = "us-montana-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Nebraska = {
+    id = "PIA-US Nebraska";
+    uuid = "a6f06fbb-a800-4919-93e5-bb9a16daa95b";
+    remote = "us-nebraska-pf.privacy.network 1197 udp";
+  };
+  PIA-US_New_Hampshire = {
+    id = "PIA-US New Hampshire";
+    uuid = "6f1de4c0-cfae-4076-b5a6-8ca9cc3692dd";
+    remote = "us-new-hampshire-pf.privacy.network 1197 udp";
+  };
+  PIA-US_New_Mexico = {
+    id = "PIA-US New Mexico";
+    uuid = "4a5c9eb7-5c48-4fc0-95d8-90cb52980c5a";
+    remote = "us-new-mexico-pf.privacy.network 1197 udp";
+  };
+  PIA-US_New_York = {
+    id = "PIA-US New York";
+    uuid = "0b22b9ac-62d6-4281-bf06-164897425a8a";
+    remote = "us-newyorkcity.privacy.network 1197 udp";
+  };
+  PIA-US_North_Carolina = {
+    id = "PIA-US North Carolina";
+    uuid = "f7cc5b75-f187-4094-a8b0-0b1cd49cff33";
+    remote = "us-north-carolina-pf.privacy.network 1197 udp";
+  };
+  PIA-US_North_Dakota = {
+    id = "PIA-US North Dakota";
+    uuid = "9ac6bfcc-025f-4f6a-bba3-239dae83fd01";
+    remote = "us-north-dakota-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Ohio = {
+    id = "PIA-US Ohio";
+    uuid = "e4cd9166-d19e-4f36-af98-4e9d03f8da90";
+    remote = "us-ohio-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Oklahoma = {
+    id = "PIA-US Oklahoma";
+    uuid = "648a8ecc-0243-4afa-a4dc-62d02ef87b93";
+    remote = "us-oklahoma-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Oregon = {
+    id = "PIA-US Oregon";
+    uuid = "78b9ddb5-45f1-48a8-9a01-2766d5f940d4";
+    remote = "us-oregon-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Pennsylvania = {
+    id = "PIA-US Pennsylvania";
+    uuid = "02e3387e-d86d-4290-a800-92b12fa57bac";
+    remote = "us-pennsylvania-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Rhode_Island = {
+    id = "PIA-US Rhode Island";
+    uuid = "29a8371c-1ab6-4af7-9c54-1b2a75811773";
+    remote = "us-rhode-island-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Salt_Lake_City = {
+    id = "PIA-US Salt Lake City";
+    uuid = "e9b8aef8-5b53-4849-8056-aaa3cfaca916";
+    remote = "us-saltlakecity.privacy.network 1197 udp";
+  };
+  PIA-US_Seattle = {
+    id = "PIA-US Seattle";
+    uuid = "7b6bc52f-870b-4e17-9e95-8237b9be0094";
+    remote = "us-seattle.privacy.network 1197 udp";
+  };
+  PIA-US_Silicon_Valley = {
+    id = "PIA-US Silicon Valley";
+    uuid = "4ba7b32d-c1cd-4b97-8594-fcb430d803cc";
+    remote = "us-siliconvalley.privacy.network 1197 udp";
+  };
+  PIA-US_South_Carolina = {
+    id = "PIA-US South Carolina";
+    uuid = "43a9f6e5-100c-480c-bf7b-793a3424fa2f";
+    remote = "us-south-carolina-pf.privacy.network 1197 udp";
+  };
+  PIA-US_South_Dakota = {
+    id = "PIA-US South Dakota";
+    uuid = "14797740-9f99-48c2-8c28-f86e48ee2279";
+    remote = "us-south-dakota-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Tennessee = {
+    id = "PIA-US Tennessee";
+    uuid = "35ed88c5-5414-4c0f-96a1-8e2359cb639b";
+    remote = "us-tennessee-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Texas = {
+    id = "PIA-US Texas";
+    uuid = "81d51b51-ac2a-4b2b-b042-53945b7352c3";
+    remote = "us-texas.privacy.network 1197 udp";
+  };
+  PIA-US_Vermont = {
+    id = "PIA-US Vermont";
+    uuid = "414ee06b-276e-479a-b07d-1913da366e96";
+    remote = "us-vermont-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Virginia = {
+    id = "PIA-US Virginia";
+    uuid = "3422b133-e163-40a4-9bed-04de08c06b19";
+    remote = "us-virginia-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Washington_DC = {
+    id = "PIA-US Washington DC";
+    uuid = "c0fa3733-57fc-4e7e-899f-50994d4a6157";
+    remote = "us-washingtondc.privacy.network 1197 udp";
+  };
+  PIA-US_West = {
+    id = "PIA-US West";
+    uuid = "1d7f4ebd-2758-4807-886b-8190550db374";
+    remote = "us3.privacy.network 1197 udp";
+  };
+  PIA-US_West_Streaming_Optimized = {
+    id = "PIA-US West Streaming Optimized";
+    uuid = "9b67301c-ea3b-4c39-9f38-9c2763201475";
+    remote = "us-streaming-2.privacy.network 1197 udp";
+  };
+  PIA-US_West_Virginia = {
+    id = "PIA-US West Virginia";
+    uuid = "96c69877-ac54-4dbb-a2bb-43fd72994249";
+    remote = "us-west-virginia-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Wilmington = {
+    id = "PIA-US Wilmington";
+    uuid = "eb6273e2-d88d-4498-b75f-b6470b1129d7";
+    remote = "us-wilmington.privacy.network 1197 udp";
+  };
+  PIA-US_Wisconsin = {
+    id = "PIA-US Wisconsin";
+    uuid = "52764382-f5af-4ce0-9655-6f26eb909cd1";
+    remote = "us-wisconsin-pf.privacy.network 1197 udp";
+  };
+  PIA-US_Wyoming = {
+    id = "PIA-US Wyoming";
+    uuid = "ea2dff72-9003-4c87-a953-c09219a5a9ed";
+    remote = "us-wyoming-pf.privacy.network 1197 udp";
+  };
+  PIA-Venezuela = {
+    id = "PIA-Venezuela";
+    uuid = "5b25f469-e2bf-41b2-803c-7179ca86bfef";
+    remote = "venezuela.privacy.network 1197 udp";
+  };
+  PIA-Vietnam = {
+    id = "PIA-Vietnam";
+    uuid = "f5136c30-e8f6-4b17-a48a-4874b7b7f660";
+    remote = "vietnam.privacy.network 1197 udp";
+  };
 }

--- a/modules/services/ttyd.linux.nix
+++ b/modules/services/ttyd.linux.nix
@@ -18,7 +18,7 @@ in
       enable = true;
       inherit port;
       interface = "127.0.0.1";
-      user = env.user;
+      inherit (env) user;
       writeable = true;
       entrypoint = [ (lib.getExe pkgs.zsh) ];
     };


### PR DESCRIPTION
## Summary
- Adds opt-in `modules/profiles/dev-workstation.nix` for the common program set (`agents`, `devPkgs`, `jsPackageSecurity`, `claude-code`, `cursor`, `gws`, `localsend`, `obsidian`, `herdr`, `micro`), with Linux-only `rtk`/`hunk`/`scripts.bun`/`kitty`
- Shrinks `hosts/{akatosh,azura,mara,boethiah}.nix` to machine deltas; drops redundant `kitty`/`rofi`/`ydotool` on Hyprland desktops
- Defaults `agents.sandbox.enable` on when `agents.enable` is on

Closes #32

## Test plan
- [x] `just check`
- [x] Spot-check one Linux host rebuild (`nh os build` / `just build`)
- [ ] Spot-check Darwin (`nh darwin build` on boethiah) — confirms `hunk.enable = false` still wins